### PR TITLE
Add RDS certs to tozny/docker image

### DIFF
--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -1,0 +1,44 @@
+# Dockerfile written by Eric Mann <eric@tozny.com>
+#
+# Work derived from official PHP Docker Library:
+# Copyright (c) Docker, Inc.
+# Copyright (c) 2016 Tozny, LLC
+
+FROM alpine:3.4
+
+# Default to UTF-8 file.encoding
+ENV LANG C.UTF-8
+
+# add a simple script that can auto-detect the appropriate JAVA_HOME value
+# based on whether the JDK or only the JRE is installed
+RUN { \
+		echo '#!/bin/sh'; \
+		echo 'set -e'; \
+		echo; \
+		echo 'dirname "$(dirname "$(readlink -f "$(which javac || which java)")")"'; \
+	} > /usr/local/bin/docker-java \
+	&& chmod +x /usr/local/bin/docker-java
+
+ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk
+ENV PATH $PATH:$JAVA_HOME/bin
+ENV JAVA_VERSION 8u111
+ENV JAVA_ALPINE_VERSION 8.111.14-r0
+
+RUN set -x \
+	&& apk add --no-cache \
+		openjdk8="$JAVA_ALPINE_VERSION" \
+		libsodium \
+		bash \
+		coreutils \
+		curl \
+		openssl \
+	&& [ "$JAVA_HOME" = "$(docker-java)" ] \
+	&& ln -s /usr/lib/libsodium.so.18 /usr/lib/libsodium.so
+
+ADD import-rds-certs.sh /bin/
+
+MAINTAINER Eric Mann
+
+WORKDIR /data
+
+CMD ["/bin/sh"]

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -36,6 +36,7 @@ RUN set -x \
 	&& ln -s /usr/lib/libsodium.so.18 /usr/lib/libsodium.so
 
 ADD import-rds-certs.sh /bin/
+RUN import-rds-certs.sh
 
 MAINTAINER Eric Mann
 

--- a/java/import-rds-certs.sh
+++ b/java/import-rds-certs.sh
@@ -1,0 +1,35 @@
+#! /bin/sh
+
+# based on https://gist.github.com/steini/d40a59ae4a9036c4d5a4
+# This script takes a .pem certificate chain file, and breaks it into individual
+# certificate files, for easy ingestion into the java trustStore
+
+OLDDIR="$PWD"
+
+if [ -z "$CACERTS_FILE" ]; then
+    CACERTS_FILE=$JAVA_HOME/jre/lib/security/cacerts
+fi
+
+mkdir /tmp/rds-ca && cd /tmp/rds-ca
+
+echo "Downloading RDS certificates..."
+
+curl https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem > rds-combined-ca-bundle.pem
+
+csplit -sz rds-combined-ca-bundle.pem '/-BEGIN CERTIFICATE-/' '{*}'
+
+# csplit outputs files in format xx00, xx01...etc
+for CERT in xx*; do
+    # extract a human-readable alias from the cert
+    ALIAS=$(openssl x509 -noout -text -in $CERT | grep "Subject:" | sed 's/^.*CN=//')
+    echo "importing $ALIAS"
+    # import the cert into the default java keystore
+    keytool -import \
+            -keystore  $CACERTS_FILE \
+            -storepass changeit -noprompt \
+            -alias "$ALIAS" -file $CERT
+done
+
+cd "$OLDDIR"
+
+rm -r /tmp/rds-ca


### PR DESCRIPTION
Custom init script to import AWS RDS certificate chain into the java trustStore for services that use RDS SSL/TLS. The dockerfile is copied from https://github.com/tozny/docker-java and moved here as this repo should eventually hold all tozny public docker builds.