### PR TITLE
Add public tozny golang docker files to central repo.

### DIFF
--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -1,0 +1,3 @@
+FROM golang:1.11-alpine
+RUN apk add --no-cache openssh git
+ENV GO111MODULE=on

--- a/golang/README.md
+++ b/golang/README.md
@@ -1,0 +1,4 @@
+docker-go
+---------
+
+Stable Docker container for Go 1.11 built on top of Alpine Linux.


### PR DESCRIPTION
Formerly kept in separate private repo: https://github.com/tozny/docker-go