### PR TITLE
Adding config for building custom keycloak image

### DIFF
--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -11,8 +11,8 @@ ENV PROXY_ADDRESS_FORWARDING false
 ENV JBOSS_HOME /opt/jboss/keycloak
 ENV LANG en_US.UTF-8
 
-ARG GIT_REPO
-ARG GIT_BRANCH
+ARG GIT_REPO=tozny/keycloak
+ARG GIT_BRANCH=build-custom-image
 ARG KEYCLOAK_DIST=https://downloads.jboss.org/keycloak/$KEYCLOAK_VERSION/keycloak-$KEYCLOAK_VERSION.tar.gz
 
 USER root

--- a/keycloak/Makefile
+++ b/keycloak/Makefile
@@ -21,7 +21,7 @@ docker-buildx-init:
 	docker buildx ls
 
 build-all: docker-buildx-init
-	docker buildx build --platform linux/arm64,linux/amd64 --tag tozny/keycloak:latest ./
+	docker buildx build --platform linux/amd64 --tag tozny/keycloak:hotfix ./
 
 push-all: docker-buildx-init
-	docker buildx build --push --platform linux/arm64,linux/amd64 --tag tozny/keycloak:latest ./
+	docker buildx build --push --platform linux/amd64 --tag tozny/keycloak:hotfix ./

--- a/keycloak/Makefile
+++ b/keycloak/Makefile
@@ -21,7 +21,18 @@ docker-buildx-init:
 	docker buildx ls
 
 build-all: docker-buildx-init
-	docker buildx build --platform linux/amd64 --tag tozny/keycloak:hotfix ./
+	docker buildx build --platform linux/arm64,linux/amd64 --tag tozny/keycloak:latest ./
 
 push-all: docker-buildx-init
-	docker buildx build --push --platform linux/amd64 --tag tozny/keycloak:hotfix ./
+	docker buildx build --push --platform linux/arm64,linux/amd64 --tag tozny/keycloak:latest ./
+
+
+# Don't export to shell to keep stable per invoke of make / prevent dynamic interpolation
+# Variables used to uniquely tag docker builds
+export TIMESTAMP=$(shell date +%s)
+export GIT_SHORT_HASH=$(shell echo $(shell git rev-parse HEAD) | cut -c 1-8)
+IMAGE_TAG=$(GIT_SHORT_HASH)-$(TIMESTAMP)
+
+hotfix:
+	docker build --no-cache --tag tozny/keycloak:hotfix-$(IMAGE_TAG) ./
+	docker push tozny/keycloak:hotfix-$(IMAGE_TAG)


### PR DESCRIPTION
builds a tozny keycloak image that identity service will consume: https://hub.docker.com/layers/tozny/keycloak/hotfix/images/sha256-51b01a1b5601739e7e0e34c8bd0c0eee6ae2e8100c0ee0e9a816bb7bb4f80f12?context=repo 

Currently prod has this image running 