### PR TITLE
Make redirector compatible with OpenShift

### DIFF
--- a/redirector/Dockerfile
+++ b/redirector/Dockerfile
@@ -2,6 +2,8 @@ FROM nginx:alpine
 
 ENV NGINX_CONF=/etc/nginx/conf.d/default.conf
 COPY default.conf ${NGINX_CONF}
+RUN chgrp 0 ${NGINX_CONF}
+RUN chmod g+w ${NGINX_CONF}
 COPY docker-entrypoint.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]

--- a/redirector/Dockerfile
+++ b/redirector/Dockerfile
@@ -2,8 +2,12 @@ FROM nginx:alpine
 
 ENV NGINX_CONF=/etc/nginx/conf.d/default.conf
 COPY default.conf ${NGINX_CONF}
-RUN chgrp 0 ${NGINX_CONF}
-RUN chmod g+w ${NGINX_CONF}
+
+# Allow _group_ root to edit nginx conf for OpenShift compatibility
+# Must be whole directory, because of sed temp files
+RUN chgrp -R 0 $(dirname ${NGINX_CONF})
+RUN chmod -R g+w $(dirname ${NGINX_CONF})
+
 COPY docker-entrypoint.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]

--- a/redirector/README.md
+++ b/redirector/README.md
@@ -2,11 +2,22 @@
 
 Sends HTTP 301 redirect during any request to this container. Useful for starting domain name changes of web services.
 
-# Use Example
+# Use Examples
 
+With defaults:
 ```
 docker run -it --rm \
   -p 8080:80 \
+  -e REDIRECT_FQDN=https://tozny.com \
+  tozny/redirector
+```
+
+Listen on alternate port, and serve temporary redirect:
+```
+docker run -it --rm \
+  -p 8080:8080 \
+  -e LISTEN_PORT=8080 \
+  -e REDIRECT_CODE=302 \
   -e REDIRECT_FQDN=https://tozny.com \
   tozny/redirector
 ```

--- a/redirector/default.conf
+++ b/redirector/default.conf
@@ -1,4 +1,4 @@
 server {
-    listen         80;
-    return 301     REDIRECT_FQDN;
+    listen         LISTEN_PORT;
+    return REDIRECT_CODE     REDIRECT_FQDN;
 }

--- a/redirector/docker-entrypoint.sh
+++ b/redirector/docker-entrypoint.sh
@@ -2,5 +2,7 @@
 
 # Uses | as delimeter or else sed fails because FQDN contains /, which interferes with default sed delimeter
 sed -i "s|REDIRECT_FQDN|$REDIRECT_FQDN|" $NGINX_CONF
+sed -i "s|LISTEN_PORT|${LISTEN_PORT:-80}|" $NGINX_CONF
+sed -i "s|REDIRECT_CODE|${REDIRECT_CODE:-301}|" $NGINX_CONF
 
 exec "$@"


### PR DESCRIPTION
A few small tweaks to the redirector container, to make it compatible with OpenShift. Also, allow setting a different redirect code (eg. 302).

Shouldn't alter default behavior at all.